### PR TITLE
Ortho process

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -46,3 +46,8 @@ jobs:
       - name: Run YAPF code style check
         run: |
           yapf -d ./*.py --style=.style.yapf 2>&1
+
+      - name: Snakemake lint
+        run: |
+          pip install snakemake --quiet
+          snakemake --lint --configfile snakemake_config.yml

--- a/Snakefile
+++ b/Snakefile
@@ -1,13 +1,13 @@
 import os
 import tools
 
-configfile: "/blue/ewhite/everglades/everwatch-workflow/snakemake_config.yml"
+configfile: "snakemake_config.yml"
 
 # Check if the test environment variable exists
 test_env_name = "TEST_ENV"
 # Hardcode true for the moment while we're testing for safety.
 test_env_set = True
-working_dir = "/blue/ewhite/everglades_test" if test_env_set else "/blue/ewhite/everglades"
+working_dir = config["working_dir_test"] if test_env_set else config["working_dir"]
 
 # Discover flights from raw data; year is the last '_'-delimited token in the folder name
 RAW_DATA = glob_wildcards(f"{working_dir}/open_drone_map/RawData/SkyScoutFlights/{{site}}/{{flight}}")
@@ -23,16 +23,17 @@ if site_year_combos:
 else:
     SITES_SY, YEARS_SY = [], []
 
+
 def flights_in_year_site(wildcards):
     basepath = f"{working_dir}/predictions"
     flights_in_year_site = []
     for site, year, flight in zip(SITES, YEARS, FLIGHTS):
         flight_path = os.path.join(basepath, year, site, f"{flight}_projected.shp")
-        # Assuming there is a tools.get_event function
         event = tools.get_event(flight_path)
         if site == wildcards.site and year == wildcards.year and event[0] == "primary":
             flights_in_year_site.append(flight_path)
     return flights_in_year_site
+
 
 rule all:
     input:
@@ -49,20 +50,24 @@ rule all:
 
 rule create_orthomosaics:
     input:
-        raw_data_root = f"{working_dir}/open_drone_map/RawData/SkyScoutFlights/{{site}}/{{flight}}"
+        raw_data_root=f"{working_dir}/open_drone_map/RawData/SkyScoutFlights/{{site}}/{{flight}}"
     output:
-        orthomosaic = f"{working_dir}/orthomosaics/{{year}}/{{site}}/{{flight}}.tif"
+        orthomosaic=f"{working_dir}/orthomosaics/{{year}}/{{site}}/{{flight}}.tif"
+    log:
+        f"{working_dir}/logs/create_orthomosaics/{{year}}/{{site}}/{{flight}}.log"
+    conda: "envs/odm.yml"
     params:
-        scratch_dir = f"{working_dir}/open_drone_map/ODM_Processed",
-        slurm_extra = "--gpus=1"
+        scratch_dir=f"{working_dir}/open_drone_map/ODM_Processed",
+        slurm_extra="--gpus=1"
     wildcard_constraints:
-        year = r"\d{4}"
+        year=r"\d{4}"
     threads: 8
     resources:
-        mem_mb = 65536,
-        runtime = 720
+        mem_mb=65536,
+        runtime=720
     shell:
-        "bash process_ortho.sh {input.raw_data_root} {output.orthomosaic} {params.scratch_dir}"
+        "bash process_ortho.sh {input.raw_data_root} {output.orthomosaic} {params.scratch_dir} > {log} 2>&1"
+
 
 rule project_mosaics:
     input:
@@ -70,19 +75,24 @@ rule project_mosaics:
     output:
         projected=f"{working_dir}/projected_mosaics/{{year}}/{{site}}/{{flight}}_projected.tif",
         webmercator=f"{working_dir}/projected_mosaics/webmercator/{{year}}/{{site}}/{{flight}}_projected.tif"
+    log:
+        f"{working_dir}/logs/project_mosaics/{{year}}/{{site}}/{{flight}}.log"
     conda: "envs/mbtiles.yml"
     threads: 1
     resources:
         mem_mb=32000,
         project_mosaic_slot=1
     shell:
-        "python project_orthos.py {input.orthomosaic}"
+        "python project_orthos.py {input.orthomosaic} > {log} 2>&1"
+
 
 rule predict_birds:
     input:
         projected=f"{working_dir}/projected_mosaics/{{year}}/{{site}}/{{flight}}_projected.tif"
     output:
         f"{working_dir}/predictions/{{year}}/{{site}}/{{flight}}_projected.shp"
+    log:
+        f"{working_dir}/logs/predict_birds/{{year}}/{{site}}/{{flight}}.log"
     conda: "envs/predict.yml"
     threads: 1
     resources:
@@ -90,19 +100,23 @@ rule predict_birds:
         mem_mb=40000,
         predict_birds_slot=1
     shell:
-        "python predict.py {input.projected}"
+        "python predict.py {input.projected} > {log} 2>&1"
+
 
 rule combine_birds_site_year:
     input:
         flights_in_year_site
     output:
         f"{working_dir}/predictions/{{year}}/{{site}}/{{site}}_{{year}}_combined.shp"
+    log:
+        f"{working_dir}/logs/combine_birds_site_year/{{year}}/{{site}}.log"
     conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=8000
     shell:
-        "python combine_birds_site_year.py {input}"
+        "python combine_birds_site_year.py {input} > {log} 2>&1"
+
 
 rule combine_predicted_birds:
     input:
@@ -110,36 +124,45 @@ rule combine_predicted_birds:
                zip, site=SITES_SY, year=YEARS_SY)
     output:
         f"{working_dir}/everwatch-workflow/App/Zooniverse/data/PredictedBirds.zip"
+    log:
+        f"{working_dir}/logs/combine_predicted_birds.log"
     conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=8000
     shell:
-        "python combine_bird_predictions.py {input}"
+        "python combine_bird_predictions.py {input} > {log} 2>&1"
+
 
 rule detect_nests:
     input:
         f"{working_dir}/predictions/{{year}}/{{site}}/{{site}}_{{year}}_combined.shp"
     output:
         f"{working_dir}/detected_nests/{{year}}/{{site}}/{{site}}_{{year}}_detected_nests.shp"
+    log:
+        f"{working_dir}/logs/detect_nests/{{year}}/{{site}}.log"
     conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=8000
     shell:
-        "python nest_detection.py {input}"
+        "python nest_detection.py {input} > {log} 2>&1"
+
 
 rule process_nests:
     input:
         f"{working_dir}/detected_nests/{{year}}/{{site}}/{{site}}_{{year}}_detected_nests.shp"
     output:
         f"{working_dir}/processed_nests/{{year}}/{{site}}/{{site}}_{{year}}_processed_nests.shp"
+    log:
+        f"{working_dir}/logs/process_nests/{{year}}/{{site}}.log"
     conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=8000
     shell:
-        "python process_nests.py {input}"
+        "python process_nests.py {input} > {log} 2>&1"
+
 
 rule combine_nests:
     input:
@@ -147,50 +170,64 @@ rule combine_nests:
                zip, site=SITES_SY, year=YEARS_SY)
     output:
         f"{working_dir}/everwatch-workflow/App/Zooniverse/data/nest_detections_processed.zip"
+    log:
+        f"{working_dir}/logs/combine_nests.log"
     conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=8000
     shell:
-        "python combine_nests.py {input}"
+        "python combine_nests.py {input} > {log} 2>&1"
+
 
 rule create_mbtile:
     input:
         f"{working_dir}/projected_mosaics/webmercator/{{year}}/{{site}}/{{flight}}_projected.tif"
     output:
         f"{working_dir}/mapbox/{{year}}/{{site}}/{{flight}}.mbtiles"
+    log:
+        f"{working_dir}/logs/create_mbtile/{{year}}/{{site}}/{{flight}}.log"
+    params:
+        mapbox_param=config["mapbox-param"]
     conda: "envs/mbtiles.yml"
     threads: 1
     resources:
         mem_mb=32000
     shell:
-        "python mbtile.py {input} {config[mapbox-param]}"
+        "python mbtile.py {input} {params.mapbox_param} > {log} 2>&1"
+
 
 rule upload_mapbox:
     input:
         f"{working_dir}/mapbox/{{year}}/{{site}}/{{flight}}.mbtiles"
     output:
         f"{working_dir}/mapbox/last_uploaded/{{year}}/{{site}}/{{flight}}.mbtiles"
+    log:
+        f"{working_dir}/logs/upload_mapbox/{{year}}/{{site}}/{{flight}}.log"
     conda: "envs/mbtiles.yml"
     threads: 1
     resources:
         mem_mb=4000
     shell:
         """
-        python upload_mapbox.py {input}
+        python upload_mapbox.py {input} > {log} 2>&1
         touch {output}
         """
+
 
 rule update_everwatch_predictions:
     input:
         f"{working_dir}/everwatch-workflow/App/Zooniverse/data/PredictedBirds.zip"
     output:
         f"{working_dir}/everwatch-workflow/App/Zooniverse/data/forecast_web_updated.txt"
+    log:
+        f"{working_dir}/logs/update_everwatch_predictions.log"
+    conda: "envs/everwatch.yml"
     threads: 1
     resources:
         mem_mb=4000
     shell:
         """
-        bash archive_predictions.sh
+        bash archive_predictions.sh > {log} 2>&1
         touch {output}
         """

--- a/Snakefile
+++ b/Snakefile
@@ -8,16 +8,19 @@ test_env_name = "TEST_ENV"
 test_env_set = os.environ.get(test_env_name)
 working_dir = "/blue/ewhite/everglades_test" if test_env_set else "/blue/ewhite/everglades"
 
-# Define wildcards for orthomosaics
-ORTHOMOSAICS = glob_wildcards(f"{working_dir}/orthomosaics/{{year}}/{{site}}/{{flight}}.tif")
-FLIGHTS = ORTHOMOSAICS.flight
-SITES = ORTHOMOSAICS.site
-YEARS = ORTHOMOSAICS.year
+# Discover flights from raw data; year is the last '_'-delimited token in the folder name
+RAW_DATA = glob_wildcards(f"{working_dir}/open_drone_map/RawData/SkyScoutFlights/{{site}}/{{flight}}")
+FLIGHTS = RAW_DATA.flight
+SITES = RAW_DATA.site
+YEARS = [f.split('_')[-1] for f in FLIGHTS]
 
 
 # Extract combinations of SITES and YEARS
 site_year_combos = {*zip(SITES, YEARS)}
-SITES_SY, YEARS_SY = list(zip(*site_year_combos))
+if site_year_combos:
+    SITES_SY, YEARS_SY = list(zip(*site_year_combos))
+else:
+    SITES_SY, YEARS_SY = [], []
 
 def flights_in_year_site(wildcards):
     basepath = f"{working_dir}/predictions"
@@ -42,6 +45,23 @@ rule all:
         expand(f"{working_dir}/mapbox/last_uploaded/{{year}}/{{site}}/{{flight}}.mbtiles",
                zip, site=SITES, year=YEARS, flight=FLIGHTS)
 
+
+rule create_orthomosaics:
+    input:
+        raw_data_root = f"{working_dir}/open_drone_map/RawData/SkyScoutFlights/{{site}}/{{flight}}"
+    output:
+        orthomosaic = f"{working_dir}/orthomosaics/{{year}}/{{site}}/{{flight}}.tif"
+    params:
+        scratch_dir = f"{working_dir}/open_drone_map/ODM_Processed"
+    wildcard_constraints:
+        year = r"\d{4}"
+    resources:
+        mem_mb = 65536,
+        cpus = 8,
+        gpus = 1,
+        runtime = 720
+    shell:
+        "bash process_ortho.sh {input.raw_data_root} {output.orthomosaic} {params.scratch_dir}"
 
 rule project_mosaics:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -5,7 +5,8 @@ configfile: "/blue/ewhite/everglades/everwatch-workflow/snakemake_config.yml"
 
 # Check if the test environment variable exists
 test_env_name = "TEST_ENV"
-test_env_set = os.environ.get(test_env_name)
+# Hardcode true for the moment while we're testing for safety.
+test_env_set = True
 working_dir = "/blue/ewhite/everglades_test" if test_env_set else "/blue/ewhite/everglades"
 
 # Discover flights from raw data; year is the last '_'-delimited token in the folder name
@@ -52,13 +53,13 @@ rule create_orthomosaics:
     output:
         orthomosaic = f"{working_dir}/orthomosaics/{{year}}/{{site}}/{{flight}}.tif"
     params:
-        scratch_dir = f"{working_dir}/open_drone_map/ODM_Processed"
+        scratch_dir = f"{working_dir}/open_drone_map/ODM_Processed",
+        slurm_extra = "--gpus=1"
     wildcard_constraints:
         year = r"\d{4}"
+    threads: 8
     resources:
         mem_mb = 65536,
-        cpus = 8,
-        gpus = 1,
         runtime = 720
     shell:
         "bash process_ortho.sh {input.raw_data_root} {output.orthomosaic} {params.scratch_dir}"

--- a/envs/everwatch.yml
+++ b/envs/everwatch.yml
@@ -12,3 +12,4 @@ dependencies:
   - shapely
   - numpy
   - snakemake
+  - snakemake-executor-plugin-slurm

--- a/envs/odm.yml
+++ b/envs/odm.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.10
+  - uv

--- a/everglades_dryrun_workflow.sh
+++ b/everglades_dryrun_workflow.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
-#SBATCH --job-name=everwatch_workflow_dryrun
-#SBATCH --mail-user=henrysenyondo@ufl.edu
-#SBATCH --mail-type=FAIL
-#SBATCH --cpus-per-task=8
-#SBATCH --mem=100gb
-#SBATCH --time=09:30:00
-#SBATCH --gpus=1
-#SBATCH --output=/blue/ewhite/everglades/everwatch-workflow/logs/everglades_dryrun_workflow.out
-#SBATCH --error=/blue/ewhite/everglades/everwatch-workflow/logs/everglades_dryrun_workflow.err
+# Run from a tmux session on the login node:  bash everglades_dryrun_workflow.sh
 
 source /blue/ewhite/hpc_maintenance/githubdeploytoken.txt
 
 echo "INFO: [$(date "+%Y-%m-%d %H:%M:%S")] Starting everglades workflow on $(hostname) in $(pwd)"
 
-echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Loading required modules"
 source /etc/profile.d/modules.sh
-
 ml conda
 conda activate everwatch
 export PYTHONNOUSERSITE=1
@@ -32,14 +22,13 @@ cd /blue/ewhite/everglades/everwatch-workflow/
 snakemake --unlock
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Starting Snakemake pipeline"
 snakemake \
+  --executor slurm \
   --printshellcmds \
   --keep-going \
   --use-conda \
   --rerun-incomplete \
-  --latency-wait 10 \
-  --cores 8 \
-  --jobs 2 \
-  --resources mem_mb=100000 gpu=1 project_mosaic_slot=1 predict_birds_slot=1
+  --latency-wait 60 \
+  --jobs 20
 
 echo ""
 echo "=============================="

--- a/everglades_workflow.sh
+++ b/everglades_workflow.sh
@@ -1,37 +1,27 @@
 #!/bin/bash
-#SBATCH --job-name=everglades_workflow 
-#SBATCH --mail-user=henrysenyondo@ufl.edu 
-#SBATCH --mail-type=FAIL
-#SBATCH --cpus-per-task=20
-#SBATCH --mem=160gb
-#SBATCH --gpus=1
-#SBATCH --time=80:00:00
-#SBATCH --output=/blue/ewhite/everglades/everwatch-workflow/logs/everglades_workflow.out
-#SBATCH --error=/blue/ewhite/everglades/everwatch-workflow/logs/everglades_workflow.err
+# Run from a tmux session on the login node:  bash everglades_workflow.sh
 
 source /blue/ewhite/hpc_maintenance/githubdeploytoken.txt
 
 echo "INFO: [$(date "+%Y-%m-%d %H:%M:%S")] Starting everglades workflow on $(hostname) in $(pwd)"
 
-echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Loading required modules"
 source /etc/profile.d/modules.sh
-
 ml conda
 conda activate everwatch
 export PYTHONNOUSERSITE=1
+
 cd /blue/ewhite/everglades/everwatch-workflow/
 
 snakemake --unlock
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Starting Snakemake pipeline"
 snakemake \
+  --executor slurm \
   --printshellcmds \
   --keep-going \
   --use-conda \
   --rerun-incomplete \
-  --latency-wait 10 \
-  --cores 20 \
-  --jobs 2 \
-  --resources mem_mb=160000 gpu=1 project_mosaic_slot=1 predict_birds_slot=1
+  --latency-wait 60 \
+  --jobs 20
 
 echo ""
 echo "=============================="

--- a/process_ortho.sh
+++ b/process_ortho.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Usage: bash process_ortho.sh <source_folder> <output_tif> <working_dir>
+#   source_folder  - directory containing raw JPG images
+#   output_tif     - destination path for the final orthomosaic .tif
+#   working_dir    - scratch directory for ODM intermediate files
+
+set -euo pipefail
+
+SOURCE_FOLDER="${1:?Usage: $0 <source_folder> <output_tif> <working_dir>}"
+OUTPUT_PATH="${2:?Usage: $0 <source_folder> <output_tif> <working_dir>}"
+WORKING_DIR="${3:?Usage: $0 <source_folder> <output_tif> <working_dir>}"
+ODM_SIF="/blue/ewhite/everglades/open_drone_map/odm.sif"
+
+source /blue/ewhite/everglades/open_drone_map/odm_env/bin/activate
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+BASENAME=$(basename "$SOURCE_FOLDER")
+TARGET_DIR="${WORKING_DIR}/${BASENAME}"
+
+printenv | grep -i slurm | sort
+
+mkdir -p "${TARGET_DIR}/code"
+
+# Perform PPK geotagging
+python "${SCRIPT_DIR}/wispr_to_odm_ppk.py" "${SOURCE_FOLDER}" "${TARGET_DIR}/code/geo.txt" || \
+{ echo "Failed to find a PPK coordinate file. Processing will use EXIF GPS data only."; }
+
+# Copy JPG files
+echo "Copying images from ${SOURCE_FOLDER} to ${TARGET_DIR}/code/images"
+mkdir -p "${TARGET_DIR}/code/images"
+rsync -av --include='*.JPG' --include='*.jpg' --exclude='*' "${SOURCE_FOLDER}/" "${TARGET_DIR}/code/images/" || \
+{ echo "Warning: No JPG files found in ${SOURCE_FOLDER}"; exit 1; }
+
+# Run GCP detection
+mkdir -p "${TARGET_DIR}/gcp"
+gcp-detect "${SOURCE_FOLDER}" --output "${TARGET_DIR}/gcp" gcps.csv && \
+    cp "${TARGET_DIR}/gcp/gcp_list.txt" "${TARGET_DIR}/code/gcp_list.txt" || \
+    echo "No GCPs found, proceeding without."
+
+module load cuda
+
+# Run ODM with the target directory as project path
+echo "Running ODM on ${TARGET_DIR}"
+srun apptainer run --nv --bind "${TARGET_DIR}:/project" \
+    "$ODM_SIF" \
+    --project-path /project \
+    --max-concurrency 8 \
+    --orthophoto-resolution 2 \
+    --optimize-disk-space \
+    --build-overviews \
+    --cog
+
+# Clean up images
+echo "Removing image folder ${TARGET_DIR}/code/images"
+rm -rf "${TARGET_DIR}/code/images"
+
+# Copy orthomosaic to the requested output path
+ODM_OUTPUT="${TARGET_DIR}/code/odm_orthophoto/odm_orthophoto.tif"
+echo "Copying ${ODM_OUTPUT} to ${OUTPUT_PATH}"
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+cp "${ODM_OUTPUT}" "${OUTPUT_PATH}"
+
+echo "Setting permissions on target folder"
+bash /home/veitchmichaelisj/bin/group-permissions-update.sh "${TARGET_DIR}"
+
+echo "Completed processing ${BASENAME}"

--- a/process_ortho.sh
+++ b/process_ortho.sh
@@ -41,7 +41,7 @@ module load cuda
 
 # Run ODM with the target directory as project path
 echo "Running ODM on ${TARGET_DIR}"
-srun apptainer run --nv --bind "${TARGET_DIR}:/project" \
+srun --gpus=1 apptainer run --nv --bind "${TARGET_DIR}:/project" \
     "$ODM_SIF" \
     --project-path /project \
     --max-concurrency 8 \

--- a/snakemake_config.yml
+++ b/snakemake_config.yml
@@ -1,1 +1,3 @@
 mapbox-param: ""
+working_dir: "/blue/ewhite/everglades"
+working_dir_test: "/blue/ewhite/everglades_test"

--- a/wispr_to_odm_ppk.py
+++ b/wispr_to_odm_ppk.py
@@ -20,10 +20,8 @@ with open(csv_files[0]) as infile, open(args.output_txt, "w") as outfile:
 
     for row in reader:
         # ODM format: filename lon lat alt yaw pitch roll [h_acc v_acc]
-        outfile.write(
-            f"{row['image_name']} {row['longitude']} {row['latitude']} "
-            f"{row['altitude']} {row['gimbal_yaw']} {row['gimbal_pitch']} "
-            f"{row['gimbal_roll']} {row['x_accuracy']} {row['z_accuracy']}\n"
-        )
+        outfile.write(f"{row['image_name']} {row['longitude']} {row['latitude']} "
+                      f"{row['altitude']} {row['gimbal_yaw']} {row['gimbal_pitch']} "
+                      f"{row['gimbal_roll']} {row['x_accuracy']} {row['z_accuracy']}\n")
 
 print(f"Created {args.output_txt}")

--- a/wispr_to_odm_ppk.py
+++ b/wispr_to_odm_ppk.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Convert WISPR exif_image_list.csv to OpenDroneMap geo.txt format."""
+
+import argparse
+import csv
+from pathlib import Path
+
+parser = argparse.ArgumentParser(description="Convert WISPR CSV to ODM geo.txt")
+parser.add_argument("root_dir", help="Root directory to search for exif_image_list.csv")
+parser.add_argument("output_txt", help="Output geo.txt file for ODM")
+args = parser.parse_args()
+
+csv_files = list(Path(args.root_dir).rglob("exif_image_list.csv"))
+if len(csv_files) == 0:
+    raise SystemExit("Error: No exif_image_list.csv found")
+
+with open(csv_files[0]) as infile, open(args.output_txt, "w") as outfile:
+    reader = csv.DictReader(infile)
+    outfile.write("EPSG:4326\n")
+
+    for row in reader:
+        # ODM format: filename lon lat alt yaw pitch roll [h_acc v_acc]
+        outfile.write(
+            f"{row['image_name']} {row['longitude']} {row['latitude']} "
+            f"{row['altitude']} {row['gimbal_yaw']} {row['gimbal_pitch']} "
+            f"{row['gimbal_roll']} {row['x_accuracy']} {row['z_accuracy']}\n"
+        )
+
+print(f"Created {args.output_txt}")


### PR DESCRIPTION
@henrykironde could you add a branch for the ortho processing so I can PR to it? That might be better than going into main until we've tested this.

This PR implements:

- Updates snakemake to look for raw flight data in the standard path. We don't have a year separator currently. Might be a good idea?
- Runs some processing to extract GCPs and PPK, and the ODM container on the flight, copying the output to the expected dir in `everglades/orthomosaics`
- Rest of snakemake continues as normal

I added a linter for the snakemake file, this complained about a few things...

I've added logging replication from SLURM (snakemake linter requires a `log` directive, but it just indicates where the log file for a job ought to go, we have to pipe output to it).

I haven't added the alignment code yet, because there are some subtleties there about which flight we pick as the anchor - and it doesn't matter really, we can always align the data after the maps are generated.

Also updated the submission script to use the slurm executor plugin which we need to install in the env on HPG.